### PR TITLE
Add include directive for external_string.h in owned_string.h

### DIFF
--- a/include/zelix/container/owned_string.h
+++ b/include/zelix/container/owned_string.h
@@ -28,6 +28,7 @@
 //
 
 #pragma once
+#include "external_string.h"
 #include <cstring>
 #include <xxh3.h>
 #include "string_utils.h"


### PR DESCRIPTION
This pull request introduces a minor update to the `owned_string.h` header file to improve modularity and ensure proper dependency inclusion.

* Dependency management:
  * Added an `#include "external_string.h"` directive at the top of `owned_string.h` to explicitly include the external string dependency.