### PR TITLE
Replace buffer assignment with emplace_back in io.h to optimize chara…

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -161,7 +161,7 @@ namespace zelix::stl
                     flush(); ///< Flush the buffer if it's full
                 }
 
-                buffer[buffer.pos()] = s[i];
+                buffer.emplace_back(s[i]); ///< Add the character to the buffer
                 buffer.advance(); ///< Advance the position in the buffer
             }
 


### PR DESCRIPTION
This pull request makes a small improvement to the buffer handling in the `zelix::stl` namespace, specifically in the `include/zelix/container/io.h` file. The change updates how characters are added to the buffer, using a more idiomatic method for appending elements.

* Changed from directly assigning to a buffer index to using `buffer.emplace_back(s[i])` for adding characters, which is safer and more expressive.…cter addition