### PR TITLE
Remove unnecessary buffer advancement in character addition to stream

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -162,7 +162,6 @@ namespace zelix::stl
                 }
 
                 buffer.emplace_back(s[i]); ///< Add the character to the buffer
-                buffer.advance(); ///< Advance the position in the buffer
             }
 
             return *this;


### PR DESCRIPTION
This pull request makes a minor change to the `zelix::stl` namespace in `include/zelix/container/io.h`, specifically in the logic for adding characters to a buffer. The `buffer.advance()` call was removed, which simplifies the buffer update process.…line code