### PR TITLE
Fix operator<< template signature to improve type constraints for integral types

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -141,7 +141,7 @@ namespace zelix::stl
         }
 
         template <typename T>
-        std::enable_if_t<std::is_integral_v<T>, ostream&>
+        std::enable_if_t<std::is_integral_v<T>>
         operator<<(T val)
         {
             char i_buffer[32];


### PR DESCRIPTION
This pull request makes a small change to the `operator<<` template in the `zelix::stl` namespace. The change removes the return type of `ostream&` from the template specialization for integral types, likely to fix a compilation or type deduction issue.

* Removed `ostream&` return type from the `operator<<` template for integral types in `include/zelix/container/io.h`.