### PR TITLE
Add support for double and float in ostream

### DIFF
--- a/include/zelix/algorithm/ftoi.h
+++ b/include/zelix/algorithm/ftoi.h
@@ -29,12 +29,11 @@
 
 #pragma once
 #include <cstring>
-#include <cmath>
 
 #include "zelix/container/string_utils.h"
 
 namespace zelix::stl::algorithm {
-    inline void dtoi(char* buffer, double value, int decimals)
+    inline size_t dtoi(char* buffer, double value, int decimals)
     {
         if (decimals < 0) decimals = 0;
 
@@ -95,5 +94,6 @@ namespace zelix::stl::algorithm {
         }
 
         buffer[pos] = '\0';
+        return pos; // Return the length of the resulting string
     }
 }

--- a/include/zelix/algorithm/ftoi.h
+++ b/include/zelix/algorithm/ftoi.h
@@ -1,0 +1,99 @@
+/*
+        ==== The Zelix Programming Language ====
+---------------------------------------------------------
+  - This file is part of the Zelix Programming Language
+    codebase. Zelix is a fast, statically-typed and
+    memory-safe programming language that aims to
+    match native speeds while staying highly performant.
+---------------------------------------------------------
+  - Zelix is categorized as free software; you can
+    redistribute it and/or modify it under the terms of
+    the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+---------------------------------------------------------
+  - Zelix is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even
+    the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+---------------------------------------------------------
+  - You should have received a copy of the GNU General
+    Public License along with Zelix. If not, see
+    <https://www.gnu.org/licenses/>.
+*/
+
+//
+// Created by rodrigo on 8/22/25.
+//
+
+#pragma once
+#include <cstring>
+#include <cmath>
+
+#include "zelix/container/string_utils.h"
+
+namespace zelix::stl::algorithm {
+    inline void dtoi(char* buffer, double value, int decimals)
+    {
+        if (decimals < 0) decimals = 0;
+
+        // Handle negative numbers
+        const bool isNegative = value < 0;
+        if (isNegative) value = -value;
+
+        // Get integer part
+        auto int_part = static_cast<long long>(value);
+
+        // Get fractional part
+        double frac_part = value - int_part;
+
+        // Handle rounding
+        double rounding = 0.5;
+        for (int i = 0; i < decimals; ++i) rounding /= 10.0;
+        frac_part += rounding;
+        if (frac_part >= 1.0) {
+            int_part += 1;
+            frac_part -= 1.0;
+        }
+
+        // Convert integer part to string
+        char int_buffer[32];
+        int i = 0;
+        if (int_part == 0) {
+            int_buffer[i++] = '0';
+        } else {
+            long long tmp = int_part;
+            while (tmp > 0) {
+                int_buffer[i++] = '0' + (tmp % 10);
+                tmp /= 10;
+            }
+            // Reverse the string
+            for (int j = 0; j < i/2; ++j) {
+                const char t = int_buffer[j];
+                int_buffer[j] = int_buffer[i-1-j];
+                int_buffer[i-1-j] = t;
+            }
+        }
+        int_buffer[i] = '\0';
+
+        // Start filling the main buffer
+        int pos = 0;
+        if (isNegative) buffer[pos++] = '-';
+        strcpy(buffer + pos, int_buffer);
+        pos += str::len(int_buffer);
+
+        // Add decimal point and fractional digits
+        if (decimals > 0) {
+            buffer[pos++] = '.';
+            for (int d = 0; d < decimals; ++d) {
+                frac_part *= 10;
+                const int digit = static_cast<int>(frac_part);
+                buffer[pos++] = '0' + digit;
+                frac_part -= digit;
+            }
+        }
+
+        buffer[pos] = '\0';
+    }
+}

--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -30,6 +30,7 @@
 #pragma once
 #include "display.h"
 #include "owned_string.h"
+#include "zelix/algorithm/ftoi.h"
 #include "zelix/algorithm/itoa.h"
 #ifndef _WIN32
 #   include "ring_buffer.h"
@@ -46,7 +47,6 @@ namespace zelix::stl
 #   ifndef _WIN32
         ring_buffer<char, Capacity> buffer; ///< Ring buffer to hold the output data
 #   endif
-
         void do_write(const char *data, const size_t size)
         {
 #       ifndef _WIN32
@@ -83,6 +83,22 @@ namespace zelix::stl
 #       else
             std::cout << data; ///< Use standard output for Windows
 #       endif
+        }
+
+        template <typename T, std::enable_if_t<std::is_integral_v<T>>>
+        void do_write_integral(T val)
+        {
+            if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>)
+            {
+                // Convert floating point numbers to string
+                char f_buffer[64];
+                do_write(f_buffer, algorithm::dtoi(f_buffer, static_cast<double>(val), 2));
+                return;
+            }
+
+            char i_buffer[32];
+            const size_t len = algorithm::itoa(val, i_buffer);
+            do_write(i_buffer, len);
         }
 
     public:
@@ -140,13 +156,63 @@ namespace zelix::stl
             return *this;
         }
 
-        template <typename T>
-        std::enable_if_t<std::is_integral_v<T>>
-        operator<<(T val)
+        ostream &operator<<(short val)
         {
-            char i_buffer[32];
-            const size_t len = algorithm::itoa(val, i_buffer);
-            do_write(i_buffer, len);
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(int val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(long val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(long long val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(unsigned short val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(unsigned int val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(unsigned long val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(unsigned long long val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(float val)
+        {
+            do_write(val);
+            return *this;
+        }
+
+        ostream &operator<<(double val)
+        {
+            do_write(val);
             return *this;
         }
 


### PR DESCRIPTION
This pull request introduces a new floating-point-to-string conversion utility and refactors the `ostream` implementation to provide better support for both integral and floating-point types. The changes make the output stream interface more robust and consistent, especially when handling numeric types.

### Floating-point to string conversion

* Added a new `dtoi` function in `zelix::stl::algorithm` for converting floating-point numbers to their string representation with a specified number of decimal places (`include/zelix/algorithm/ftoi.h`).
* Included the new `ftoi.h` header in `io.h` to make the floating-point conversion available for output streams (`include/zelix/container/io.h`).

### ostream refactoring and improvements

* Added a `do_write_integral` helper template to handle both integral and floating-point values, using `dtoi` for floating-point types and `itoa` for integral types (`include/zelix/container/io.h`).
* Replaced the previous SFINAE-based `operator<<` template with explicit overloads for all standard integer and floating-point types, ensuring proper handling and output for each type (`include/zelix/container/io.h`).

### Code organization

* Minor formatting and whitespace adjustments to improve code readability in `io.h`.