### PR TITLE
Refactor ostream operator<< to use do_write_integral for float and duble types

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -206,13 +206,13 @@ namespace zelix::stl
 
         ostream &operator<<(float val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(double val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 


### PR DESCRIPTION
This pull request updates the way floating-point values are written to the `ostream` in the `zelix::stl` namespace by changing the internal method used for output. Instead of calling `do_write`, the code now calls `do_write_integral` for both `float` and `double` types.

- Changed the implementation of `ostream::operator<<` for `float` and `double` to use `do_write_integral` instead of `do_write` in `include/zelix/container/io.h`