### PR TITLE
Fix memory bug

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -85,20 +85,27 @@ namespace zelix::stl
 #       endif
         }
 
-        template <typename T, std::enable_if_t<std::is_integral_v<T>>>
+        template <typename T>
         void do_write_integral(T val)
         {
             if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>)
             {
                 // Convert floating point numbers to string
-                char f_buffer[64];
+                char f_buffer[64] = {};
                 do_write(f_buffer, algorithm::dtoi(f_buffer, static_cast<double>(val), 2));
-                return;
             }
-
-            char i_buffer[32];
-            const size_t len = algorithm::itoa(val, i_buffer);
-            do_write(i_buffer, len);
+            else if constexpr (std::is_integral_v<T>) {
+                char i_buffer[32] = {};
+                const size_t len = algorithm::itoa(val, i_buffer);
+                do_write(i_buffer, len);
+            }
+            else
+            {
+                static_assert(
+                    false,
+                    "Unsupported type for ostream::do_write_integral"
+                );
+            }
         }
 
     public:
@@ -156,61 +163,61 @@ namespace zelix::stl
             return *this;
         }
 
-        ostream &operator<<(short val)
+        ostream &operator<<(const short val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(int val)
+        ostream &operator<<(const int val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(long val)
+        ostream &operator<<(const long val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(long long val)
+        ostream &operator<<(const long long val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(unsigned short val)
+        ostream &operator<<(const unsigned short val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(unsigned int val)
+        ostream &operator<<(const unsigned int val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(unsigned long val)
+        ostream &operator<<(const unsigned long val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(unsigned long long val)
+        ostream &operator<<(const unsigned long long val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(float val)
+        ostream &operator<<(const float val)
         {
             do_write_integral(val);
             return *this;
         }
 
-        ostream &operator<<(double val)
+        ostream &operator<<(const double val)
         {
             do_write_integral(val);
             return *this;

--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -158,49 +158,49 @@ namespace zelix::stl
 
         ostream &operator<<(short val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(int val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(long val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(long long val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(unsigned short val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(unsigned int val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(unsigned long val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 
         ostream &operator<<(unsigned long long val)
         {
-            do_write(val);
+            do_write_integral(val);
             return *this;
         }
 

--- a/include/zelix/container/ring_buffer.h
+++ b/include/zelix/container/ring_buffer.h
@@ -219,7 +219,7 @@ namespace zelix::stl
         void write(const T *buf, const size_t count)
         {
             // Warning: it is the caller's responsibility to do bounds checking
-            memcpy(data, buf + head, count * sizeof(T));
+            memcpy(data + head, buf, count * sizeof(T));
             head += count;
         }
     };


### PR DESCRIPTION
This pull request refactors the `ostream` class in `include/zelix/container/io.h` to improve type safety and clarity when writing integral and floating-point values, and fixes a buffer copy bug in the `ring_buffer` implementation. The main changes involve consolidating the logic for writing numeric types, ensuring proper buffer initialization, and correcting a parameter order in a memory copy operation.

**Refactoring and type safety improvements in `ostream`:**

* Unified the logic for writing integral and floating-point types by updating the `do_write_integral` template method. It now handles both type categories with explicit compile-time checks and static assertions for unsupported types. Buffers used for string conversion are now zero-initialized for safety.
* Updated all `operator<<` overloads for numeric types to use the new `do_write_integral` method, and changed their parameters to be `const` for clarity and consistency.

**Bug fix in `ring_buffer`:**

* Fixed the argument order in the `memcpy` call inside the `write` method so data is copied from the input buffer to the correct position in the ring buffer, rather than the reverse.