### PR TITLE
Add ANSI color definitions for terminal output

### DIFF
--- a/include/zelix/container/ansi.h
+++ b/include/zelix/container/ansi.h
@@ -1,0 +1,58 @@
+/*
+        ==== The Zelix Programming Language ====
+---------------------------------------------------------
+  - This file is part of the Zelix Programming Language
+    codebase. Zelix is a fast, statically-typed and
+    memory-safe programming language that aims to
+    match native speeds while staying highly performant.
+---------------------------------------------------------
+  - Zelix is categorized as free software; you can
+    redistribute it and/or modify it under the terms of
+    the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+---------------------------------------------------------
+  - Zelix is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even
+    the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+---------------------------------------------------------
+  - You should have received a copy of the GNU General
+    Public License along with Zelix. If not, see
+    <https://www.gnu.org/licenses/>.
+*/
+
+//
+// Created by rodrigo on 8/22/25.
+//
+
+#pragma once
+
+
+#define ANSI_RESET "\033[0m"
+#define ANSI_BLACK "\033[30m"
+#define ANSI_RED "\033[31m"
+#define ANSI_GREEN "\033[32m"
+#define ANSI_YELLOW "\033[33m"
+#define ANSI_BLUE "\033[34m"
+#define ANSI_PURPLE "\033[35m"
+#define ANSI_CYAN "\033[36m"
+#define ANSI_WHITE "\033[37m"
+#define ANSI_BRIGHT_BLACK "\033[90m"
+#define ANSI_BRIGHT_RED "\033[91m"
+#define ANSI_BRIGHT_GREEN "\033[92m"
+#define ANSI_BRIGHT_YELLOW "\033[93m"
+#define ANSI_BRIGHT_BLUE "\033[94m"
+#define ANSI_BRIGHT_PURPLE "\033[95m"
+#define ANSI_BRIGHT_CYAN "\033[96m"
+#define ANSI_BRIGHT_WHITE "\033[97m"
+#define ANSI_BOLD "\033[1m"
+#define ANSI_BOLD_BRIGHT_BLUE "\033[1;94m"
+#define ANSI_BOLD_BRIGHT_GREEN "\033[1;92m"
+#define ANSI_BOLD_BRIGHT_RED "\033[1;91m"
+#define ANSI_BOLD_BRIGHT_YELLOW "\033[1;93m"
+#define ANSI_BOLD_BRIGHT_PURPLE "\033[1;95m"
+#define ANSI_UNDERLINE "\033[4m"
+#define ANSI_DIM "\e[2m"
+#define ANSI_DIM_END "\e[22m"


### PR DESCRIPTION
This pull request introduces a new header file, `ansi.h`, to the Zelix codebase. The file provides a comprehensive set of ANSI escape code definitions for colored and styled terminal output, along with a license and project information header.

New ANSI escape code utilities:

* Added `include/zelix/container/ansi.h` with macro definitions for various ANSI color and style codes (e.g., `ANSI_RED`, `ANSI_BOLD`, `ANSI_UNDERLINE`) to standardize terminal output formatting across the project.

Project documentation and licensing:

* Included a detailed project and licensing header at the top of `ansi.h`, outlining Zelix's goals and licensing terms under the GNU GPL.