### PR TITLE
Update destructor condition in page class for improved safety 

### DIFF
--- a/include/zelix/memory/allocator.h
+++ b/include/zelix/memory/allocator.h
@@ -77,7 +77,7 @@ namespace zelix::stl::memory
 
             ~page()
             {
-                if constexpr (CallDestructors)
+                if constexpr (!std::is_trivially_destructible_v<T> && CallDestructors)
                 {
                     // Call the destructor of all allocated objects
                     for (size_t i = 0; i < offset; ++i)
@@ -148,6 +148,6 @@ namespace zelix::stl::memory
         };
     }
 
-    template <typename T, size_t Capacity = 256, bool CallDestructors = false>
+    template <typename T, size_t Capacity = 256, bool CallDestructors = true>
     using lazy_allocator = pmr::lazy_allocator<T, Capacity, CallDestructors>; ///< Default lazy allocator type using the default page size and destructor behavior
 }


### PR DESCRIPTION
This pull request makes improvements to the `lazy_allocator` in the `zelix::stl::memory` namespace, focusing on safer object destruction and updating default template parameters. The most important changes are:

Allocator safety improvements:

* The destructor for the internal `page` struct now only calls destructors for stored objects if the type `T` is not trivially destructible and `CallDestructors` is true, preventing unnecessary destructor calls for trivial types.

Template parameter updates:

* The default value for the `CallDestructors` parameter in the `lazy_allocator` alias is changed from `false` to `true`, ensuring destructors are called by default for non-trivial types.