### PR TITLE
Add pop_back_move method to vector for efficient element removal

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -331,6 +331,20 @@ namespace zelix::stl
             }
 
             /**
+             * @brief Removes the last element from the vector and returns it by move.
+             *
+             * Decreases the size and moves the last element out of the vector.
+             * Does not call the destructor for the removed element.
+             *
+             * @return T The last element, moved from the vector.
+             * @note Use with caution: the destructor is not called for the removed element.
+             */
+            T pop_back_move() {
+                --size_;
+                return std::move(data[size_]);
+            }
+
+            /**
              * @brief Removes all elements from the vector.
              *
              * Calls the destructor for each element and resets the size to zero.


### PR DESCRIPTION
This pull request adds a new utility function to the `zelix::stl::vector` implementation. The main change is the introduction of a `pop_back_move()` method, which allows efficiently removing and moving the last element from the vector without calling its destructor. This can be useful for performance-critical code but should be used with care due to the lack of destructor invocation.

New functionality:

* Added a `pop_back_move()` method to `zelix::stl::vector`, which removes the last element by moving it out and does not call its destructor.