### PR TITLE
Enable destructors by default in allocator template for improved resource management

### DIFF
--- a/include/zelix/memory/allocator.h
+++ b/include/zelix/memory/allocator.h
@@ -96,7 +96,7 @@ namespace zelix::stl::memory
         template <
             typename T,
             size_t Capacity = 256,
-            bool CallDestructors = false,
+            bool CallDestructors = true,
             typename Allocator = resource<T>,
             typename = std::enable_if_t<
                 std::is_base_of_v<resource<T>, Allocator>


### PR DESCRIPTION
This pull request makes a small but important change to the default behavior of a template in the `zelix::stl::memory` namespace. The default value for the `CallDestructors` template parameter is now set to `true` instead of `false`, which means destructors will be called by default when using this allocator. 

([include/zelix/memory/allocator.hL99-R99](diffhunk://#diff-d0450f8fbbfc1b7bd90fcdc5843d1d513413b8e18c8ebe76601b6b7a1ece2abcL99-R99))