### PR TITLE
Add equality operator to shared_ptr for object comparison

### DIFF
--- a/include/zelix/memory/shared_ptr.h
+++ b/include/zelix/memory/shared_ptr.h
@@ -159,6 +159,11 @@ namespace zelix::stl::memory
                 return ptr; // Access the managed object
             }
 
+            bool operator==(const shared_ptr &other) const
+            {
+                return *ptr == *other.ptr; // Compare the managed objects
+            }
+
             ~shared_ptr()
             {
                 if constexpr (Concurrent)


### PR DESCRIPTION
This pull request introduces an equality comparison operator for the `shared_ptr` class in `include/zelix/memory/shared_ptr.h`. This allows two `shared_ptr` instances to be compared based on the objects they manage.

Enhancement to smart pointer functionality:

* Added an `operator==` to `shared_ptr` that compares the managed objects, enabling direct equality checks between `shared_ptr` instances.