### PR TITLE
Add dereference operator to shared_ptr for improved object access

### DIFF
--- a/include/zelix/memory/shared_ptr.h
+++ b/include/zelix/memory/shared_ptr.h
@@ -164,6 +164,11 @@ namespace zelix::stl::memory
                 return *ptr == *other.ptr; // Compare the managed objects
             }
 
+            T *operator *() const
+            {
+                return ptr; // Dereference to get the managed object
+            }
+
             ~shared_ptr()
             {
                 if constexpr (Concurrent)


### PR DESCRIPTION
This pull request introduces a new dereference operator to the `shared_ptr` implementation in `include/zelix/memory/shared_ptr.h`. This addition allows users to directly access the managed pointer using the `*` operator.

Enhancement to smart pointer usability:

* Added a `T *operator*() const` method to `shared_ptr`, enabling direct dereferencing to obtain the raw managed pointer.