### PR TITLE
Add max and min functions for integral types in zelix::stl namespace

### DIFF
--- a/include/zelix/container/math_utils.h
+++ b/include/zelix/container/math_utils.h
@@ -1,0 +1,52 @@
+/*
+        ==== The Zelix Programming Language ====
+---------------------------------------------------------
+  - This file is part of the Zelix Programming Language
+    codebase. Zelix is a fast, statically-typed and
+    memory-safe programming language that aims to
+    match native speeds while staying highly performant.
+---------------------------------------------------------
+  - Zelix is categorized as free software; you can
+    redistribute it and/or modify it under the terms of
+    the GNU General Public License as published by the
+    Free Software Foundation, either version 3 of the
+    License, or (at your option) any later version.
+---------------------------------------------------------
+  - Zelix is distributed in the hope that it will
+    be useful, but WITHOUT ANY WARRANTY; without even
+    the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public
+    License for more details.
+---------------------------------------------------------
+  - You should have received a copy of the GNU General
+    Public License along with Zelix. If not, see
+    <https://www.gnu.org/licenses/>.
+*/
+
+//
+// Created by rodrigo on 8/24/25.
+//
+
+#pragma once
+#include <type_traits>
+
+namespace zelix::stl
+{
+    template <
+        typename T,
+        std::enable_if_t<std::is_integral_v<T>>
+    >
+    T max(T a, T b)
+    {
+        return a > b ? a : b;
+    }
+
+    template <
+        typename T,
+        std::enable_if_t<std::is_integral_v<T>>
+    >
+    T min(T a, T b)
+    {
+        return a > b ? a : b;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new header file, `math_utils.h`, to the Zelix standard library. The file provides utility functions for mathematical operations on integral types and includes licensing information for the project.

New math utilities:

* Added `max` and `min` template functions for integral types in the `zelix::stl` namespace, allowing easy computation of maximum and minimum values for integers.

Project documentation and licensing:

* Included detailed GPLv3 license and project information at the top of the new `math_utils.h` file to clarify usage and distribution terms.