### PR TITLE
Enhance max and min functions to support different integral types

### DIFF
--- a/include/zelix/container/math_utils.h
+++ b/include/zelix/container/math_utils.h
@@ -34,18 +34,22 @@ namespace zelix::stl
 {
     template <
         typename T,
-        std::enable_if_t<std::is_integral_v<T>>
+        typename U,
+        std::enable_if_t<std::is_integral_v<T>>,
+        std::enable_if_t<std::is_integral_v<U>>
     >
-    T max(T a, T b)
+    T max(T a, U b)
     {
         return a > b ? a : b;
     }
 
     template <
         typename T,
-        std::enable_if_t<std::is_integral_v<T>>
+        typename U,
+        std::enable_if_t<std::is_integral_v<T>>,
+        std::enable_if_t<std::is_integral_v<U>>
     >
-    T min(T a, T b)
+    T min(T a, U b)
     {
         return a > b ? a : b;
     }


### PR DESCRIPTION
This pull request updates the `max` and `min` utility functions in `math_utils.h` to allow comparing integral values of different types, improving their flexibility and type safety.

Enhancements to math utility functions:

* Updated the `max` and `min` templates to accept two potentially different integral types (`T` and `U`) instead of requiring both arguments to be of the same type, by adding a second template parameter and corresponding type constraints.
* Both functions now accept mixed-type integral arguments, such as comparing an `int` with a `long`, as long as both types are integral.