### PR TITLE
Refactor ANSI color constants for improved organization

### DIFF
--- a/include/zelix/container/ansi.h
+++ b/include/zelix/container/ansi.h
@@ -61,11 +61,23 @@ namespace zelix::stl::ansi
     namespace bold
     {
         inline constexpr const char bold[] = ANSI_BOLD;
-        inline constexpr const char bright_blue[] = ANSI_BOLD_BRIGHT_BLUE;
-        inline constexpr const char bright_green[] = ANSI_BOLD_BRIGHT_GREEN;
-        inline constexpr const char bright_red[] = ANSI_BOLD_BRIGHT_RED;
-        inline constexpr const char bright_yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
-        inline constexpr const char bright_purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+        inline constexpr const char blue[] = ANSI_BOLD_BRIGHT_BLUE;
+        inline constexpr const char green[] = ANSI_BOLD_BRIGHT_GREEN;
+        inline constexpr const char red[] = ANSI_BOLD_BRIGHT_RED;
+        inline constexpr const char yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
+        inline constexpr const char purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+    }
+
+    namespace bright
+    {
+        inline constexpr const char black[] = ANSI_BRIGHT_BLACK;
+        inline constexpr const char red[] = ANSI_BRIGHT_RED;
+        inline constexpr const char green[] = ANSI_BRIGHT_GREEN;
+        inline constexpr const char yellow[] = ANSI_BRIGHT_YELLOW;
+        inline constexpr const char blue[] = ANSI_BRIGHT_BLUE;
+        inline constexpr const char purple[] = ANSI_BRIGHT_PURPLE;
+        inline constexpr const char cyan[] = ANSI_BRIGHT_CYAN;
+        inline constexpr const char white[] = ANSI_BRIGHT_WHITE;
     }
 
     inline constexpr const char reset[] = ANSI_RESET;
@@ -77,14 +89,6 @@ namespace zelix::stl::ansi
     inline constexpr const char purple[] = ANSI_PURPLE;
     inline constexpr const char cyan[] = ANSI_CYAN;
     inline constexpr const char white[] = ANSI_WHITE;
-    inline constexpr const char bright_black[] = ANSI_BRIGHT_BLACK;
-    inline constexpr const char bright_red[] = ANSI_BRIGHT_RED;
-    inline constexpr const char bright_green[] = ANSI_BRIGHT_GREEN;
-    inline constexpr const char bright_yellow[] = ANSI_BRIGHT_YELLOW;
-    inline constexpr const char bright_blue[] = ANSI_BRIGHT_BLUE;
-    inline constexpr const char bright_purple[] = ANSI_BRIGHT_PURPLE;
-    inline constexpr const char bright_cyan[] = ANSI_BRIGHT_CYAN;
-    inline constexpr const char bright_white[] = ANSI_BRIGHT_WHITE;
     inline constexpr const char underline[] = ANSI_UNDERLINE;
     inline constexpr const char dim[] = ANSI_DIM;
     inline constexpr const char dim_end[] = ANSI_DIM_END;


### PR DESCRIPTION
This pull request refactors the organization of ANSI color code constants in the `zelix::stl::ansi` namespace. The main changes involve moving the bright color constants into a new `bright` namespace and adjusting naming for consistency, making the color code usage clearer and more maintainable.

**ANSI color code organization:**

* Moved bright color constants from the main namespace to a new `bright` namespace for better separation and clarity (`include/zelix/container/ansi.h`). [[1]](diffhunk://#diff-80b821a9b696bb3c98da467d24e556891d71ab660cead9f1a7005077aeb2dafaL64-R80) [[2]](diffhunk://#diff-80b821a9b696bb3c98da467d24e556891d71ab660cead9f1a7005077aeb2dafaL80-L87)
* Renamed `bold::bright_*` constants to `bold::color` (e.g., `bold::bright_blue` to `bold::blue`) to simplify naming and usage (`include/zelix/container/ansi.h`).

These changes help keep the ANSI color definitions organized and easier to use in code.