### PR TITLE
Refactor ansi.h

### DIFF
--- a/include/zelix/container/ansi.h
+++ b/include/zelix/container/ansi.h
@@ -47,6 +47,11 @@
 #define ANSI_BRIGHT_CYAN "\033[96m"
 #define ANSI_BRIGHT_WHITE "\033[97m"
 #define ANSI_BOLD "\033[1m"
+#define ANSI_BOLD_BLUE "\033[1;34m"
+#define ANSI_BOLD_GREEN "\033[1;32m"
+#define ANSI_BOLD_RED "\033[1;31m"
+#define ANSI_BOLD_YELLOW "\033[1;33m"
+#define ANSI_BOLD_PURPLE "\033[1;35m"
 #define ANSI_BOLD_BRIGHT_BLUE "\033[1;94m"
 #define ANSI_BOLD_BRIGHT_GREEN "\033[1;92m"
 #define ANSI_BOLD_BRIGHT_RED "\033[1;91m"
@@ -61,11 +66,20 @@ namespace zelix::stl::ansi
     namespace bold
     {
         inline constexpr const char bold[] = ANSI_BOLD;
-        inline constexpr const char blue[] = ANSI_BOLD_BRIGHT_BLUE;
-        inline constexpr const char green[] = ANSI_BOLD_BRIGHT_GREEN;
-        inline constexpr const char red[] = ANSI_BOLD_BRIGHT_RED;
-        inline constexpr const char yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
-        inline constexpr const char purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+        inline constexpr const char blue[] = ANSI_BOLD_BLUE;
+        inline constexpr const char green[] = ANSI_BOLD_GREEN;
+        inline constexpr const char red[] = ANSI_BOLD_RED;
+        inline constexpr const char yellow[] = ANSI_BOLD_YELLOW;
+        inline constexpr const char purple[] = ANSI_BOLD_PURPLE;
+
+        namespace bright
+        {
+            inline constexpr const char blue[] = ANSI_BOLD_BRIGHT_BLUE;
+            inline constexpr const char green[] = ANSI_BOLD_BRIGHT_GREEN;
+            inline constexpr const char red[] = ANSI_BOLD_BRIGHT_RED;
+            inline constexpr const char yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
+            inline constexpr const char purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+        }
     }
 
     namespace bright

--- a/include/zelix/container/ansi.h
+++ b/include/zelix/container/ansi.h
@@ -61,11 +61,23 @@ namespace zelix::stl::ansi
     namespace bold
     {
         inline constexpr const char bold[] = ANSI_BOLD;
-        inline constexpr const char bright_blue[] = ANSI_BOLD_BRIGHT_BLUE;
-        inline constexpr const char bright_green[] = ANSI_BOLD_BRIGHT_GREEN;
-        inline constexpr const char bright_red[] = ANSI_BOLD_BRIGHT_RED;
-        inline constexpr const char bright_yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
-        inline constexpr const char bright_purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+        inline constexpr const char blue[] = ANSI_BOLD_BRIGHT_BLUE;
+        inline constexpr const char green[] = ANSI_BOLD_BRIGHT_GREEN;
+        inline constexpr const char red[] = ANSI_BOLD_BRIGHT_RED;
+        inline constexpr const char yellow[] = ANSI_BOLD_BRIGHT_YELLOW;
+        inline constexpr const char purple[] = ANSI_BOLD_BRIGHT_PURPLE;
+    }
+
+    namespace bright
+    {
+        inline constexpr const char black[] = ANSI_BRIGHT_BLACK;
+        inline constexpr const char red[] = ANSI_BRIGHT_RED;
+        inline constexpr const char green[] = ANSI_BRIGHT_GREEN;
+        inline constexpr const char yellow[] = ANSI_BRIGHT_YELLOW;
+        inline constexpr const char blue[] = ANSI_BRIGHT_BLUE;
+        inline constexpr const char purple[] = ANSI_BRIGHT_PURPLE;
+        inline constexpr const char cyan[] = ANSI_BRIGHT_CYAN;
+        inline constexpr const char white[] = ANSI_BRIGHT_WHITE;
     }
 
     inline constexpr const char reset[] = ANSI_RESET;
@@ -77,14 +89,6 @@ namespace zelix::stl::ansi
     inline constexpr const char purple[] = ANSI_PURPLE;
     inline constexpr const char cyan[] = ANSI_CYAN;
     inline constexpr const char white[] = ANSI_WHITE;
-    inline constexpr const char bright_black[] = ANSI_BRIGHT_BLACK;
-    inline constexpr const char bright_red[] = ANSI_BRIGHT_RED;
-    inline constexpr const char bright_green[] = ANSI_BRIGHT_GREEN;
-    inline constexpr const char bright_yellow[] = ANSI_BRIGHT_YELLOW;
-    inline constexpr const char bright_blue[] = ANSI_BRIGHT_BLUE;
-    inline constexpr const char bright_purple[] = ANSI_BRIGHT_PURPLE;
-    inline constexpr const char bright_cyan[] = ANSI_BRIGHT_CYAN;
-    inline constexpr const char bright_white[] = ANSI_BRIGHT_WHITE;
     inline constexpr const char underline[] = ANSI_UNDERLINE;
     inline constexpr const char dim[] = ANSI_DIM;
     inline constexpr const char dim_end[] = ANSI_DIM_END;


### PR DESCRIPTION
This pull request refactors and extends the ANSI color code definitions and their corresponding C++ constants in `include/zelix/container/ansi.h`. The changes improve the organization and accessibility of both bold and bright color codes, grouping them more logically under relevant namespaces.

**ANSI color code additions and namespace reorganization:**

* Added new ANSI escape code definitions for bold variants of blue, green, red, yellow, and purple (`ANSI_BOLD_BLUE`, etc.) to the macro section.
* Updated the `zelix::stl::ansi::bold` namespace to include standard bold colors (`blue`, `green`, `red`, `yellow`, `purple`) and moved the bright bold colors into a nested `bright` namespace for better organization.
* Introduced a new top-level `bright` namespace under `zelix::stl::ansi` for bright color constants, replacing the previous flat definitions and improving clarity and structure. [[1]](diffhunk://#diff-80b821a9b696bb3c98da467d24e556891d71ab660cead9f1a7005077aeb2dafaL64-R94) [[2]](diffhunk://#diff-80b821a9b696bb3c98da467d24e556891d71ab660cead9f1a7005077aeb2dafaL80-L87)
* Removed the previous flat `bright_*` color constants from the main namespace, consolidating them under the new `bright` namespace.