### PR TITLE
Refactor cout and cerr aliases to use references 

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -256,6 +256,6 @@ namespace zelix::stl
 #   endif
     inline ostream<STDOUT_FILENO, 1024> stdout; ///< Standard output stream
     inline ostream<STDERR_FILENO, 1024> stderr; ///< Standard error stream
-    inline auto cout = stdout; ///< Alias for standard output stream
-    inline auto cerr = stderr; ///< Alias for standard error stream
+    inline auto &cout = stdout; ///< Alias for standard output stream
+    inline auto &cerr = stderr; ///< Alias for standard error stream
 }


### PR DESCRIPTION
This pull request makes a small but important change to the way output stream aliases are defined in the `zelix::stl` namespace. The aliases for `cout` and `cerr` now refer to `stdout` and `stderr` by reference instead of by value, ensuring proper stream behavior and avoiding unnecessary copies.

- Changed `cout` and `cerr` to be references to `stdout` and `stderr` instead of copies, improving correctness and efficiency in `include/zelix/container/io.h`.