### PR TITLE
Make stream PMR-Friendly and allow custom initial capacity on vectors

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -53,6 +53,7 @@ namespace zelix::stl
         template <
             typename T,
             double GrowthFactor = 1.8,
+            double InitialCapacity = 25,
             typename Allocator = memory::resource<T>,
             typename = std::enable_if_t<
                 std::is_base_of_v<memory::resource<T>, Allocator>
@@ -72,7 +73,7 @@ namespace zelix::stl
             void init()
             {
                 initialized = true;
-                capacity_ = 32;
+                capacity_ = InitialCapacity;
                 data = Allocator::arr(capacity_);
             }
 
@@ -617,6 +618,6 @@ namespace zelix::stl
         };
     }
 
-    template <typename T, double GrowthFactor = 1.8>
-    using vector = pmr::vector<T, GrowthFactor, memory::resource<T>>; ///< Default vector type using the default allocator
+    template <typename T, double GrowthFactor = 1.8, double InitialCapacity = 25>
+    using vector = pmr::vector<T, GrowthFactor, InitialCapacity, memory::resource<T>>; ///< Default vector type using the default allocator
 }

--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -53,7 +53,7 @@ namespace zelix::stl
         template <
             typename T,
             double GrowthFactor = 1.8,
-            double InitialCapacity = 25,
+            size_t InitialCapacity = 25,
             typename Allocator = memory::resource<T>,
             typename = std::enable_if_t<
                 std::is_base_of_v<memory::resource<T>, Allocator>
@@ -618,6 +618,6 @@ namespace zelix::stl
         };
     }
 
-    template <typename T, double GrowthFactor = 1.8, double InitialCapacity = 25>
+    template <typename T, double GrowthFactor = 1.8, size_t InitialCapacity = 25>
     using vector = pmr::vector<T, GrowthFactor, InitialCapacity, memory::resource<T>>; ///< Default vector type using the default allocator
 }


### PR DESCRIPTION
This pull request updates the `zelix::stl` container library to add support for customizable initial capacity in both `vector` and `stream` containers, and improves allocator flexibility. The changes introduce an `InitialCapacity` template parameter to allow users to specify the starting size of these containers, and refactor the default type aliases accordingly.

**Container customization and flexibility:**

* Added an `InitialCapacity` template parameter (defaulting to 25) to the `pmr::vector` and `pmr::stream` classes, allowing users to customize the starting capacity of these containers. (`include/zelix/container/vector.h`, `include/zelix/container/stream.h`) [[1]](diffhunk://#diff-8f206f7b7374b1fe3eca7dd258811b952f207a5d0f3309b70f8a08b00ebeafa0R56) [[2]](diffhunk://#diff-eafe385f59b05b01a4b3b78833954840e8cff9e19118e348366349e6e39e3595L36-R49)
* Updated the internal initialization logic in `vector` to use the new `InitialCapacity` parameter instead of a hardcoded value. (`include/zelix/container/vector.h`)

**Type alias updates:**

* Modified the `vector` and `stream` type aliases to include the `InitialCapacity` parameter, ensuring the default types reflect the new customization options. (`include/zelix/container/vector.h`, `include/zelix/container/stream.h`) [[1]](diffhunk://#diff-8f206f7b7374b1fe3eca7dd258811b952f207a5d0f3309b70f8a08b00ebeafa0L620-R622) [[2]](diffhunk://#diff-eafe385f59b05b01a4b3b78833954840e8cff9e19118e348366349e6e39e3595R147-R150)