### PR TITLE
Enhance string classes

### DIFF
--- a/include/zelix/container/external_string.h
+++ b/include/zelix/container/external_string.h
@@ -51,7 +51,7 @@ namespace zelix::stl
             len = other.len;
         }
 
-        explicit external_string(const char *buffer, const size_t len)
+        external_string(const char *buffer, const size_t len)
             : buffer(buffer), len(len)
         {
             if (buffer == nullptr || len == 0)

--- a/include/zelix/container/owned_string.h
+++ b/include/zelix/container/owned_string.h
@@ -452,6 +452,11 @@ namespace zelix::stl
                 len = 0;
             }
 
+            external_string external()
+            {
+                return { buffer, len };
+            }
+
             /**
              * @brief Creates a string object that uses an external buffer without copying.
              *

--- a/include/zelix/container/unique_ptr.h
+++ b/include/zelix/container/unique_ptr.h
@@ -39,10 +39,15 @@ namespace zelix::stl
     {
         template <
             typename T,
+            bool ConcurrentAllocation,
             typename Allocator = std::conditional_t<
                 std::is_array_v<T>,
                 memory::system_array_resource<T>,
-                memory::monotonic_system_resource<T>
+                std::conditional_t<
+                    ConcurrentAllocation,
+                    memory::concurrent_monotonic_resource<T>,
+                    memory::monotonic_resource<T>
+                >
             >,
             typename = std::enable_if_t<
                 std::is_base_of_v<
@@ -148,5 +153,8 @@ namespace zelix::stl
     }
 
     template <typename T>
-    using unique_ptr = pmr::unique_ptr<T>; ///< Non-concurrent shared pointer
+    using unique_ptr = pmr::unique_ptr<T, false>; ///< Non-concurrent unique pointer
+
+    template <typename T>
+    using unique_concurrent_ptr = pmr::unique_ptr<T, true>; ///< Concurrent unique pointer
 }

--- a/include/zelix/memory/monotonic.h
+++ b/include/zelix/memory/monotonic.h
@@ -55,7 +55,7 @@ namespace zelix::stl::memory
     };
 
     template <typename T>
-    class monotonic_concurrent_resource : public resource<T>
+    class concurrent_monotonic_resource : public resource<T>
     {
         static std::mutex mutex_;
         static pmr::lazy_allocator<T> allocator;


### PR DESCRIPTION
This pull request introduces new thread-safe (concurrent) variants of several core container and memory management utilities, along with supporting changes to allocator selection and stream interfaces. The main focus is to provide safer concurrent access and allocation patterns, especially for smart pointers and output streams. Additionally, some minor improvements and utility methods have been added.

**Concurrent and thread-safety enhancements:**

* Added `concurrent_ostream` class template to `io.h` for thread-safe output streams (non-Windows only), with mutex-guarded operator overloads for various types. Also introduced conditional global concurrent output streams like `cstdout` and `cstderr` when `ZELIX_STL_USE_CONCURRENT_IO` is defined. [[1]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eR265-R433) [[2]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eR443-R449) [[3]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eR459-R465)
* Introduced `concurrent_monotonic_resource` allocator in `monotonic.h` for thread-safe monotonic memory allocation, using a mutex for synchronized allocation/deallocation. Refactored the original monotonic allocator to `monotonic_resource`.

**Smart pointer improvements:**

* Updated `shared_ptr` and `unique_ptr` templates to support a `ConcurrentAllocation` boolean, allowing selection between concurrent and non-concurrent monotonic allocators. Added new aliases: `concurrent_ptr`, `concurrent_arc_ptr`, `concurrent_rc_ptr` for shared pointers, and `unique_concurrent_ptr` for unique pointers, providing clear options for concurrency and allocation strategy. [[1]](diffhunk://#diff-736e62384179cd53944d5ab00d0f67adc50c1b65a3ed6ea0482b7639d0bcc967R44-R55) [[2]](diffhunk://#diff-736e62384179cd53944d5ab00d0f67adc50c1b65a3ed6ea0482b7639d0bcc967L236-R250) [[3]](diffhunk://#diff-7ba02894b7a638ca703c885cd6b7a33eaa189d9d8877bdeac2c991310a6f996fR42-R50) [[4]](diffhunk://#diff-7ba02894b7a638ca703c885cd6b7a33eaa189d9d8877bdeac2c991310a6f996fL151-R159)

**Utility and minor changes:**

* Added an `external()` method to `owned_string` to easily obtain an `external_string` view of its buffer.
* Made the `external_string(const char*, size_t)` constructor non-explicit to allow implicit conversions.

These changes collectively enhance the library's support for concurrent programming and flexible memory/resource management.