### PR TITLE
Refactor SIMD header inclusion logic for improved readability 

### DIFF
--- a/include/zelix/container/string_utils.h
+++ b/include/zelix/container/string_utils.h
@@ -27,32 +27,29 @@
 //
 
 #pragma once
-#if defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__AVX__) || defined(__AVX2__) || \
-    (defined(__has_include) && __has_include(<immintrin.h>)))
-#   define ZELIX_STL_AVX_DEF
-#   include <immintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE4_1__) || (defined(__has_include) \
-    && __has_include(<smmintrin.h>)))
-#   define ZELIX_STL_SSE4_1_DEF
-#   include <smmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSSE3__) || (defined(__has_include) \
-    && __has_include(<tmmintrin.h>)))
-#   define ZELIX_STL_SSSE3_DEF
-#   include <tmmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE2__) || defined(_M_X64) || \
+#if defined(ZELIX_STL_USE_SIMD)
+#   if defined(__AVX__) || defined(__AVX2__) || \
+    (defined(__has_include) && __has_include(<immintrin.h>))
+#       define ZELIX_STL_AVX_DEF
+#       include <immintrin.h>
+#   elif defined(__SSE4_1__) || (defined(__has_include) \
+    && __has_include(<smmintrin.h>))
+#       define ZELIX_STL_SSE4_1_DEF
+#       include <smmintrin.h>
+#   elif defined(__SSSE3__) || (defined(__has_include) \
+    && __has_include(<tmmintrin.h>))
+#       define ZELIX_STL_SSSE3_DEF
+#       include <tmmintrin.h>
+#   elif defined(__SSE2__) || defined(_M_X64) || \
     (defined(_M_IX86_FP) && _M_IX86_FP >= 2) || \
-    (defined(__has_include) && __has_include(<emmintrin.h>)))
-#   define ZELIX_STL_SSE2_DEF
-#   include <emmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE__) || \
-    (defined(__has_include) && __has_include(<xmmintrin.h>)))
-#   define ZELIX_STL_SSE_DEF
-#   include <xmmintrin.h>
+    (defined(__has_include) && __has_include(<emmintrin.h>))
+#       define ZELIX_STL_SSE2_DEF
+#       include <emmintrin.h>
+#   elif defined(__SSE__) || \
+    (defined(__has_include) && __has_include(<xmmintrin.h>))
+#       define ZELIX_STL_SSE_DEF
+#       include <xmmintrin.h>
+#   endif
 #else
 #   include <cstring> // Fallback to standard library
 #endif


### PR DESCRIPTION
This pull request refactors the preprocessor logic for SIMD feature detection and header inclusion in `string_utils.h`. The main change is restructuring the conditional directives to improve readability and maintainability, without altering the actual feature detection logic.

Refactoring and code clarity:

* Simplified and re-indented the preprocessor conditionals for SIMD feature detection, moving all checks under a single `#if defined(ZELIX_STL_USE_SIMD)` block and using nested `#if`/`#elif` for each SIMD extension. This improves readability and makes the logic easier to follow.
* Added an explicit `#endif` for the nested SIMD checks, further clarifying the structure.