### PR TITLE
Enhance monotonic memory management

### DIFF
--- a/include/zelix/container/string_utils.h
+++ b/include/zelix/container/string_utils.h
@@ -27,32 +27,29 @@
 //
 
 #pragma once
-#if defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__AVX__) || defined(__AVX2__) || \
-    (defined(__has_include) && __has_include(<immintrin.h>)))
-#   define ZELIX_STL_AVX_DEF
-#   include <immintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE4_1__) || (defined(__has_include) \
-    && __has_include(<smmintrin.h>)))
-#   define ZELIX_STL_SSE4_1_DEF
-#   include <smmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSSE3__) || (defined(__has_include) \
-    && __has_include(<tmmintrin.h>)))
-#   define ZELIX_STL_SSSE3_DEF
-#   include <tmmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE2__) || defined(_M_X64) || \
+#if defined(ZELIX_STL_USE_SIMD)
+#   if defined(__AVX__) || defined(__AVX2__) || \
+    (defined(__has_include) && __has_include(<immintrin.h>))
+#       define ZELIX_STL_AVX_DEF
+#       include <immintrin.h>
+#   elif defined(__SSE4_1__) || (defined(__has_include) \
+    && __has_include(<smmintrin.h>))
+#       define ZELIX_STL_SSE4_1_DEF
+#       include <smmintrin.h>
+#   elif defined(__SSSE3__) || (defined(__has_include) \
+    && __has_include(<tmmintrin.h>))
+#       define ZELIX_STL_SSSE3_DEF
+#       include <tmmintrin.h>
+#   elif defined(__SSE2__) || defined(_M_X64) || \
     (defined(_M_IX86_FP) && _M_IX86_FP >= 2) || \
-    (defined(__has_include) && __has_include(<emmintrin.h>)))
-#   define ZELIX_STL_SSE2_DEF
-#   include <emmintrin.h>
-#elif defined(ZELIX_STL_USE_SIMD) && (\
-    defined(__SSE__) || \
-    (defined(__has_include) && __has_include(<xmmintrin.h>)))
-#   define ZELIX_STL_SSE_DEF
-#   include <xmmintrin.h>
+    (defined(__has_include) && __has_include(<emmintrin.h>))
+#       define ZELIX_STL_SSE2_DEF
+#       include <emmintrin.h>
+#   elif defined(__SSE__) || \
+    (defined(__has_include) && __has_include(<xmmintrin.h>))
+#       define ZELIX_STL_SSE_DEF
+#       include <xmmintrin.h>
+#   endif
 #else
 #   include <cstring> // Fallback to standard library
 #endif

--- a/include/zelix/memory/monotonic.h
+++ b/include/zelix/memory/monotonic.h
@@ -39,7 +39,7 @@ namespace zelix::stl::memory
     template <typename T>
     class monotonic_resource : public resource<T>
     {
-        static pmr::lazy_allocator<T> allocator;
+        inline static pmr::lazy_allocator<T> allocator;
 
     public:
         template <typename... Args>
@@ -57,8 +57,8 @@ namespace zelix::stl::memory
     template <typename T>
     class concurrent_monotonic_resource : public resource<T>
     {
-        static std::mutex mutex_;
-        static pmr::lazy_allocator<T> allocator;
+        inline static std::mutex mutex_;
+        inline static pmr::lazy_allocator<T> allocator;
 
     public:
         template <typename... Args>


### PR DESCRIPTION
This pull request makes a minor update to the `monotonic_resource` and `concurrent_monotonic_resource` classes in `include/zelix/memory/monotonic.h` by marking their static member variables as `inline`. This change ensures proper linkage and avoids multiple definition errors in C++17 and later.