### PR TITLE
Ensure safe deallocation of buffer in string destructor to prevent potential dangling pointer issues

### DIFF
--- a/include/zelix/container/owned_string.h
+++ b/include/zelix/container/owned_string.h
@@ -489,7 +489,11 @@ namespace zelix::stl
              */
             ~string()
             {
-                Allocator::deallocate(buffer);
+                if (buffer)
+                {
+                    Allocator::deallocate(buffer);
+                    buffer = nullptr;
+                }
             }
         };
     }


### PR DESCRIPTION
This pull request makes a minor improvement to the destructor of the `zelix::stl::string` class by ensuring that the `buffer` pointer is set to `nullptr` after deallocation. This helps prevent potential use-after-free bugs or double deallocation issues.

* Set `buffer` to `nullptr` after deallocation in the `~string()` destructor to improve memory safety.