### PR TITLE
Fix double constructor calls in lazy_allocator

### DIFF
--- a/include/zelix/memory/allocator.h
+++ b/include/zelix/memory/allocator.h
@@ -144,8 +144,7 @@ namespace zelix::stl::memory
                 // Check the free list first
                 if (!free_list.empty())
                 {
-                    T *ptr = free_list[free_list.size() - 1];
-                    free_list.pop_back();
+                    T *ptr = free_list.pop_back_move();
                     new (ptr) T(stl::forward<decltype(args)>(args)...); // Placement new to construct the object
                     return ptr;
                 }


### PR DESCRIPTION
This pull request makes a small improvement to the memory allocator implementation by optimizing how objects are retrieved from the free list.

- In `include/zelix/memory/allocator.h`, the code now uses `free_list.pop_back_move()` instead of manually indexing and then popping the last element, which simplifies and potentially optimizes the retrieval of objects from the free list.