### PR TITLE
Enhance ring_buffer

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -74,7 +74,7 @@ namespace zelix::stl
                     {
                         // Write only what fits
                         size_t space = Capacity - buffer.pos();
-                        buffer.write(ptr, space);
+                        buffer.template write<false>(ptr, space);
                         ptr += space;
                         remaining -= space;
 
@@ -88,7 +88,7 @@ namespace zelix::stl
                     return;
                 }
 
-                buffer.write(data, size);
+                buffer.template write<false>(data, size);
                 if (buffer.full())
                 {
                     flush();


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the `zelix::stl` ring buffer and IO buffer code. The main focus is on enhancing type safety, supporting move semantics, and improving buffer write operations with optional bounds checking.

**Ring Buffer Enhancements:**

* Refactored `push_back` to be a templated method supporting perfect forwarding and move semantics, and to use placement new for non-trivially copyable types. Also fixed a boundary condition in the head index check.
* Added an `unsafe_copy` helper to efficiently copy blocks of elements, using either `memcpy` for trivially copyable types or placement new otherwise.
* Refactored the `write` method to be a template with an optional `BoundsChecking` parameter (defaulting to true), using `unsafe_copy` internally and supporting buffer wrap-around.
* Added missing include for `zelix/memory/system_resource.h` in `ring_buffer.h`.

**IO Buffer Write Improvements:**

* Updated calls to `buffer.write` in `io.h` to explicitly specify the template parameter for bounds checking, ensuring consistent behavior and clarity. [[1]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eL77-R77) [[2]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eL91-R91)