### PR TITLE
Add calibrate method to set internal vector size without modifying data

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -557,6 +557,19 @@ namespace zelix::stl
             }
 
             /**
+             * @brief Sets the internal size of the vector to the specified value.
+             *
+             * This function directly sets the size\_ variable without modifying the underlying data.
+             * Use with caution: it does not construct or destroy elements.
+             *
+             * @param n The new size to set.
+             */
+            void calibrate(const size_t n)
+            {
+                size_ = n;
+            }
+
+            /**
              * @brief Destructor. Destroys all elements and releases memory.
              */
             ~vector()


### PR DESCRIPTION
This pull request adds a new method to the `zelix::stl::vector` implementation, allowing direct control over the internal size of the vector. This method is intended for advanced use cases and should be used with caution, as it does not construct or destroy elements.

New functionality:

* Added a `calibrate(size_t n)` method to `zelix::stl::vector`, which sets the internal `size_` variable directly without modifying the underlying data.