### PR TITLE
Call destructors in allocator methods and clear free list without destructors in destructor

### DIFF
--- a/include/zelix/memory/allocator.h
+++ b/include/zelix/memory/allocator.h
@@ -145,6 +145,8 @@ namespace zelix::stl::memory
                 if (!free_list.empty())
                 {
                     T *ptr = free_list.pop_back_move();
+                    ptr->~T(); // Call the destructor
+
                     new (ptr) T(stl::forward<decltype(args)>(args)...); // Placement new to construct the object
                     return ptr;
                 }
@@ -168,12 +170,12 @@ namespace zelix::stl::memory
 
             void dealloc(T *ptr)
             {
-                ptr->~T(); // Call the destructor
                 free_list.push_back(ptr);
             }
 
             ~lazy_allocator()
             {
+                free_list.calibrate(0); // Clear the free list without calling destructors
                 pages.clear(); // Clear the vector of pages
             }
         };


### PR DESCRIPTION
This pull request makes important adjustments to the `lazy_allocator` implementation in `include/zelix/memory/allocator.h`, focusing on how object lifetimes and memory management are handled. The main changes involve ensuring destructors are called at appropriate times and improving the cleanup process for the allocator's internal free list.

Object lifecycle management:

* In the allocation path, the destructor for objects is now explicitly called before reconstructing an object in-place with placement new, ensuring proper cleanup before reuse.
* The destructor call was removed from the `dealloc` method, so objects are no longer destroyed when returned to the free list, deferring destruction until reuse or allocator cleanup.

Allocator cleanup improvements:

* The `~lazy_allocator` destructor now calls `free_list.calibrate(0)` to clear the free list without invoking destructors, preventing double destruction and ensuring memory is released safely.