### PR TITLE
Remove unnecessary lock in deallocate method for improved performance

### DIFF
--- a/include/zelix/memory/monotonic.h
+++ b/include/zelix/memory/monotonic.h
@@ -89,7 +89,6 @@ namespace zelix::stl::memory
 
         static void deallocate(T *ptr) ///< Deallocate memory at given pointer
         {
-            std::unique_lock lock(mutex_);
             return allocator.dealloc(ptr);
         }
     };


### PR DESCRIPTION
This pull request makes a small change to the `deallocate` method in the `zelix::stl::memory` namespace, removing the unnecessary locking mechanism. This simplifies the code and may improve performance if locking is handled elsewhere or not needed.

* Removed the use of `std::unique_lock` in the `deallocate` method of the monotonic allocator, simplifying memory deallocation.