### PR TITLE
Fix aggressive_destroy method to handle uninitialized or null data

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -578,12 +578,13 @@ namespace zelix::stl
              */
             void aggressive_destroy()
             {
-                if (!initialized_)
+                if (!initialized_ || !data)
                 {
                     return;
                 }
 
                 Allocator::deallocate(data); // Deallocate memory
+                data = nullptr;
             }
 
             /**


### PR DESCRIPTION
This pull request makes a small improvement to the `aggressive_destroy` method in the `zelix::stl` namespace. The method now checks if `data` is null before attempting to deallocate memory, and sets `data` to `nullptr` after deallocation to prevent dangling pointers.