### PR TITLE
Refactor output stream aliases for consistency and clarity

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -452,15 +452,15 @@ namespace zelix::stl
 #   else
     inline constexpr auto endl = "\r\n"; ///< Newline character for output streams on Windows
 #   endif
-    inline ostream<STDOUT_FILENO, 1024> stdout; ///< Standard output stream
-    inline ostream<STDERR_FILENO, 1024> stderr; ///< Standard error stream
-    inline auto &cout = stdout; ///< Alias for standard output stream
-    inline auto &cerr = stderr; ///< Alias for standard error stream
+    inline ostream<STDOUT_FILENO, 1024> out; ///< Standard output stream
+    inline ostream<STDERR_FILENO, 1024> err; ///< Standard error stream
+    inline auto &cout = out; ///< Alias for standard output stream
+    inline auto &cerr = err; ///< Alias for standard error stream
 
 #   ifdef ZELIX_STL_USE_CONCURRENT_IO
     inline concurrent_ostream<STDOUT_FILENO, 1024> cstdout; ///< Standard output stream
     inline concurrent_ostream<STDERR_FILENO, 1024> cstderr; ///< Standard error stream
-    inline auto &ccout = stdout; ///< Alias for standard output stream
-    inline auto &ccerr = stderr; ///< Alias for standard error stream
+    inline auto &ccout = cstdout; ///< Alias for standard output stream
+    inline auto &ccerr = cstderr; ///< Alias for standard error stream
 #   endif
 }


### PR DESCRIPTION
This pull request updates the naming of standard output and error stream objects in the `zelix::stl` namespace to improve clarity and consistency. The most significant changes are the renaming of internal stream objects and the correction of concurrent stream aliases.

Stream object renaming and alias corrections:

* Renamed `stdout` to `out` and `stderr` to `err` for the standard output and error stream objects, and updated the `cout` and `cerr` aliases accordingly. (`include/zelix/container/io.h`)
* Fixed the concurrent stream aliases `ccout` and `ccerr` to correctly reference `cstdout` and `cstderr` instead of the non-concurrent streams. (`include/zelix/container/io.h`)