### PR TITLE
Add overloads for ostream and concurrent_ostream to support char output

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -257,6 +257,21 @@ namespace zelix::stl
     #       endif
             }
 
+            ostream &operator<<(const char s)
+            {
+#       ifndef _WIN32
+                if (buffer.full())
+                {
+                    flush(); ///< Flush the buffer if it's full
+                }
+
+                buffer.emplace_back(s); ///< Add the character to the buffer
+                return *this;
+#       else
+                std::cout << s; ///< Use standard output for Windows
+#       endif
+            }
+
             ~ostream()
             {
                 flush();
@@ -422,6 +437,16 @@ namespace zelix::stl
             }
 
             concurrent_ostream &operator<<(const char *s)
+            {
+#           ifndef _WIN32
+                std::unique_lock lock(mutex_);
+#           endif
+                ostream<FileDescriptor, Capacity, UseHeap, Allocator>::
+                    operator<<(stl::forward<decltype(s)>(s));
+                return *this;
+            }
+
+            concurrent_ostream &operator<<(const char s)
             {
 #           ifndef _WIN32
                 std::unique_lock lock(mutex_);


### PR DESCRIPTION
This pull request adds support for writing single characters to both `ostream` and `concurrent_ostream` in the `zelix::stl` namespace, improving their usability and consistency. The new overloads handle buffering and locking appropriately depending on the platform.

**Enhancements to stream output:**

* Added an `operator<<` overload for `const char` to `ostream`, which handles buffering and flushing on non-Windows platforms and falls back to `std::cout` on Windows.
* Added an `operator<<` overload for `const char` to `concurrent_ostream`, ensuring thread safety with locking and delegating to the base `ostream` implementation.