### PR TITLE
Fix missing return in overload operators

### DIFF
--- a/include/zelix/container/io.h
+++ b/include/zelix/container/io.h
@@ -298,10 +298,10 @@ namespace zelix::stl
                     buffer.emplace_back(s[i]); ///< Add the character to the buffer
                 }
 
-                return *this;
     #       else
                 std::cout << s; ///< Use standard output for Windows
     #       endif
+                return *this;
             }
 
             ostream &operator<<(const char s)
@@ -313,10 +313,10 @@ namespace zelix::stl
                 }
 
                 buffer.emplace_back(s); ///< Add the character to the buffer
-                return *this;
 #       else
                 std::cout << s; ///< Use standard output for Windows
 #       endif
+                return *this;
             }
 
             ~ostream()


### PR DESCRIPTION
This pull request makes a minor fix to the `ostream` implementation in `include/zelix/container/io.h`. The change ensures that the `return *this;` statement is consistently placed after both the buffer and standard output logic, improving code clarity and correctness across platforms.

- Code consistency and correctness:
  * Ensured `return *this;` is executed after both buffer and `std::cout` output paths in the `ostream` insertion operator overloads, fixing a potential issue on Windows and improving code clarity. [[1]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eL301-R304) [[2]](diffhunk://#diff-cb7986a1e5144a96d15dca18395ae740eb304a76d17a2103ae30363f0963830eL316-R319)