### PR TITLE
Add equality operator for string to compare with another external_string

### DIFF
--- a/include/zelix/container/owned_string.h
+++ b/include/zelix/container/owned_string.h
@@ -360,6 +360,17 @@ namespace zelix::stl
                 return memcmp(buffer, other.buffer, len) == 0;
             }
 
+            bool operator==(const external_string& other) const
+            {
+                if (buffer == nullptr)
+                {
+                    return false; // The string is empty
+                }
+
+                if (len != other.size()) return false; // Lengths differ, not equal
+                return memcmp(buffer, other.ptr(), len) == 0;
+            }
+
             bool operator==(const char *other) const
             {
                 const auto other_len = str::len(other);


### PR DESCRIPTION
This pull request adds an equality operator to improve interoperability between `owned_string` and `external_string` in the `zelix::stl` namespace. This makes it easier to directly compare these two string types for equality.

String comparison improvement:

* Added an `operator==` to `owned_string` for comparing with `external_string`, checking for null buffers, length mismatches, and using `memcmp` for content comparison.