### PR TITLE
Enhance vector

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -30,12 +30,10 @@
 #pragma once
 #include <cstdlib>
 #include <type_traits>
-#include "move.h"
 #include "zelix/except/exception.h"
 #include "zelix/except/out_of_range.h"
 #include "zelix/except/uninitialized_memory.h"
 #include "zelix/memory/array_resource.h"
-#include "zelix/memory/resource.h"
 #include "zelix/memory/system_resource.h"
 
 namespace zelix::stl

--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -29,6 +29,7 @@
 
 #pragma once
 #include <cstdlib>
+#include <initializer_list>
 #include <type_traits>
 #include "zelix/except/exception.h"
 #include "zelix/except/out_of_range.h"
@@ -149,6 +150,20 @@ namespace zelix::stl
                 other.initialized_ = false;
                 other.size_ = 0;
                 other.capacity_ = 0;
+            }
+
+            template <class U = std::initializer_list<T>>
+            vector(U &&arr)
+                : initialized_(false)
+                , data(nullptr)
+                , size_(0)
+                , capacity_(0)
+            {
+                reserve(arr.size());
+                for (size_t i = 0; i < arr.size(); ++i)
+                {
+                    emplace_back(stl::move(arr[i]));
+                }
             }
 
             vector& operator=(const vector& other)


### PR DESCRIPTION
This pull request introduces support for initializer lists to the `zelix::stl::vector` container, making it easier to construct vectors from a list of elements. Additionally, it updates the header includes to support this feature.

Initializer list support:

* Added a new constructor to `zelix::stl::vector` that accepts an `std::initializer_list`, allowing vectors to be initialized with a list of elements.
* Included the `<initializer_list>` header to enable initializer list functionality.