### PR TITLE
Fix vector initializer list

### DIFF
--- a/include/zelix/container/vector.h
+++ b/include/zelix/container/vector.h
@@ -152,19 +152,18 @@ namespace zelix::stl
                 other.capacity_ = 0;
             }
 
-            template <class U = std::initializer_list<T>>
-            vector(U &&arr)
+            vector(std::initializer_list<T> init)
                 : initialized_(false)
                 , data(nullptr)
                 , size_(0)
                 , capacity_(0)
             {
-                reserve(arr.size());
-                for (size_t i = 0; i < arr.size(); ++i)
-                {
-                    emplace_back(stl::move(arr[i]));
-                }
+                reserve(init.size());
+
+                for (auto &elem : init)
+                    emplace_back(stl::move(elem));
             }
+
 
             vector& operator=(const vector& other)
             {


### PR DESCRIPTION
This pull request updates the constructor for the `vector` class in `include/zelix/container/vector.h` to improve clarity and correctness when initializing from an initializer list.

Constructor improvements:

* Replaced the template constructor with a dedicated `std::initializer_list<T>` constructor for `vector`, ensuring proper handling of initializer lists and simplifying the constructor logic.