### PR TITLE
Enhance pair class with custom copy and move constructors and assignment operators

### DIFF
--- a/include/zelix/pair.h
+++ b/include/zelix/pair.h
@@ -29,6 +29,7 @@
 
 #pragma once
 #include "forward.h"
+#include "move.h"
 
 namespace zelix::stl
 {
@@ -49,18 +50,66 @@ namespace zelix::stl
 
     public:
         /**
-         * \brief Copy constructor.
-         *
-         * Performs a member-wise copy of the pair.
-         */
-        constexpr pair(const pair&) = default;
+ * \brief Copy constructor.
+ *
+ * Constructs a pair by copying the elements from another pair.
+ *
+ * \param other The pair to copy from.
+ */
+        pair(const pair &other)
+        {
+            new (first_) K(other.first());
+            new (second_) V(other.second());
+        }
 
         /**
          * \brief Move constructor.
          *
-         * Moves the contents of another pair into this one.
+         * Constructs a pair by moving the elements from another pair.
+         *
+         * \param other The pair to move from.
          */
-        constexpr pair(pair&&) = default;
+        pair(pair &&other) noexcept
+        {
+            new (first_) K(stl::move(other.first()));
+            new (second_) V(stl::move(other.second()));
+        }
+
+        /**
+         * \brief Copy assignment operator.
+         *
+         * Assigns the elements from another pair to this pair.
+         *
+         * \param other The pair to copy from.
+         * \return Reference to this pair.
+         */
+        pair &operator=(const pair &other)
+        {
+            if (this != &other) {
+                first() = other.first();
+                second() = other.second();
+            }
+            return *this;
+        }
+
+        /**
+         * \brief Move assignment operator.
+         *
+         * Moves the elements from another pair to this pair.
+         *
+         * \param other The pair to move from.
+         * \return Reference to this pair.
+         */
+        pair &operator=(pair &&other) noexcept
+        {
+            if (this != &other)
+            {
+                first() = stl::move(other.first());
+                second() = stl::move(other.second());
+            }
+
+            return *this;
+        }
 
         /**
          * \brief Constructs a pair from two values.


### PR DESCRIPTION
This pull request refactors the `pair` class in `include/zelix/pair.h` to provide explicit implementations for copy and move constructors and assignment operators, replacing the previous defaulted versions. These updates improve control over object construction and assignment, ensuring proper management of member objects and supporting move semantics.

**Pair class constructor and assignment improvements:**

* Added explicit copy constructor that constructs a `pair` by copying its elements from another `pair`, replacing the defaulted version.
* Added explicit move constructor that constructs a `pair` by moving its elements from another `pair`, replacing the defaulted version and using `stl::move`.
* Implemented copy assignment operator to assign elements from another `pair`, with self-assignment check.
* Implemented move assignment operator to move elements from another `pair`, with self-assignment check and use of `stl::move`.

**Include dependency update:**

* Included `move.h` to support move semantics in the `pair` class.