### PR TITLE
Add null pointer check in shared_ptr destructor for safety

### DIFF
--- a/include/zelix/shared_ptr.h
+++ b/include/zelix/shared_ptr.h
@@ -265,6 +265,8 @@ namespace zelix::stl
 
             ~shared_ptr()
             {
+                if (!ptr) return; // Nothing to do for null pointer
+
                 if constexpr (Concurrent)
                 {
                     if (atomic_ref_count && --(*atomic_ref_count) == 0)


### PR DESCRIPTION
This pull request introduces a small but important improvement to the destructor of the `shared_ptr` class in `include/zelix/shared_ptr.h`. The change ensures that if the internal pointer is null, the destructor returns immediately, preventing unnecessary operations for null pointers.

* Improved destructor logic in `shared_ptr` to early return if the managed pointer is null, avoiding unnecessary reference count checks.