### PR TITLE
Enhance shared_ptr

### DIFF
--- a/include/zelix/shared_ptr.h
+++ b/include/zelix/shared_ptr.h
@@ -168,13 +168,9 @@ namespace zelix::stl
             shared_ptr(shared_ptr &&other) noexcept
                 : ref_count(other.ref_count), ptr(other.ptr), atomic_ref_count(other.atomic_ref_count)
             {
-                add_ref_count();
-            }
-
-            shared_ptr(const shared_ptr &&other) noexcept
-                : ref_count(other.ref_count), ptr(other.ptr), atomic_ref_count(other.atomic_ref_count)
-            {
-                add_ref_count();
+                other.ptr = nullptr;
+                other.ref_count = nullptr;
+                other.atomic_ref_count = nullptr;
             }
 
             shared_ptr(const shared_ptr &other) noexcept


### PR DESCRIPTION
This pull request makes improvements to the `shared_ptr` implementation in `include/zelix/shared_ptr.h`, focusing on move semantics and comparison logic. The changes enhance the correctness of move operations and make equality checks safer for null pointers.

Improvements to move semantics:

* Updated the move constructor in `shared_ptr` to nullify the source's internal pointers (`ptr`, `ref_count`, `atomic_ref_count`) after moving, ensuring the moved-from object is left in a valid, empty state.

Enhancements to comparison logic:

* Improved the `operator==` implementation to safely handle cases where either or both `shared_ptr` instances are null, returning `true` if both are null and `false` if only one is null, before comparing the managed objects.