### PR TITLE
Fix memory bugs

### DIFF
--- a/include/zelix/memory/allocator.h
+++ b/include/zelix/memory/allocator.h
@@ -138,12 +138,10 @@ namespace zelix::stl::memory
         {
             stl::pmr::list<page<T, Capacity, CallDestructors, Allocator>, InnerAllocator> pages;
             stl::pmr::vector<T *, FreeListGrowthFactor, FreeListInitialCapacity, FreeListAllocator> free_list;
-            size_t total_allocated = 0;
 
         public:
             T *alloc(auto&&... args)
             {
-                total_allocated++;
                 // Check the free list first
                 if (!free_list.empty())
                 {
@@ -173,20 +171,6 @@ namespace zelix::stl::memory
 
             void dealloc(T *ptr)
             {
-                if (total_allocated == 0)
-                {
-                    throw except::invalid_operation("Deallocating more objects than allocated");
-                }
-
-                total_allocated--;
-                if (total_allocated == 0)
-                {
-                    // Free all memory
-                    free_list.aggressive_destroy(); // Clear the free list without calling destructors
-                    pages.clear(); // Clear the vector of pages
-                    return;
-                }
-
                 free_list.push_back(ptr);
             }
 

--- a/include/zelix/vector.h
+++ b/include/zelix/vector.h
@@ -595,6 +595,7 @@ namespace zelix::stl
 
                 Allocator::deallocate(data); // Deallocate memory
                 data = nullptr;
+                initialized_ = false;
             }
 
             /**


### PR DESCRIPTION
This pull request simplifies memory management logic in the `zelix::stl::memory` allocator and improves state tracking in the `zelix::stl::vector` implementation. The main changes involve removing the tracking of total allocations and automatic memory cleanup in the allocator, and ensuring the vector's initialization state is correctly updated after deallocation.

**Allocator logic simplification:**

* Removed the `total_allocated` counter and associated logic from the allocator in `allocator.h`, eliminating checks for over-deallocation and automatic memory cleanup when all objects are deallocated. This makes the allocator less stateful and reduces complexity. [[1]](diffhunk://#diff-d0450f8fbbfc1b7bd90fcdc5843d1d513413b8e18c8ebe76601b6b7a1ece2abcL141-L146) [[2]](diffhunk://#diff-d0450f8fbbfc1b7bd90fcdc5843d1d513413b8e18c8ebe76601b6b7a1ece2abcL176-L189)

**Vector state management:**

* Set the `initialized_` flag to `false` after deallocating memory in the `vector` implementation to accurately reflect the vector's state.